### PR TITLE
Update autolinker

### DIFF
--- a/lib/rules_core/linkify.js
+++ b/lib/rules_core/linkify.js
@@ -2,14 +2,11 @@
 //
 // Currently restricted by `inline.validateLink()` to http/https/ftp
 //
-'use strict';
+"use strict";
 
-
-var Autolinker = require('autolinker');
-
+var Autolinker = require("autolinker");
 
 var LINK_SCAN_RE = /www|@|\:\/\//;
-
 
 function isLinkOpen(str) {
   return /^<a[>\s]/i.test(str);
@@ -27,22 +24,22 @@ function createLinkifier() {
     stripPrefix: false,
     url: true,
     email: true,
-    twitter: false,
-    replaceFn: function (linker, match) {
+    mention: false,
+    replaceFn: function(match) {
       // Only collect matched strings but don't change anything.
       switch (match.getType()) {
         /*eslint default-case:0*/
-        case 'url':
+        case "url":
           links.push({
-            text: match.matchedText,
+            text: match.getMatchedText(),
             url: match.getUrl()
           });
           break;
-        case 'email':
+        case "email":
           links.push({
-            text: match.matchedText,
+            text: match.getMatchedText(),
             // normalize email protocol
-            url: 'mailto:' + match.getEmail().replace(/^mailto:/i, '')
+            url: "mailto:" + match.getEmail().replace(/^mailto:/i, "")
           });
           break;
       }
@@ -56,16 +53,31 @@ function createLinkifier() {
   };
 }
 
-
 module.exports = function linkify(state) {
-  var i, j, l, tokens, token, text, nodes, ln, pos, level, htmlLinkLevel,
-      blockTokens = state.tokens,
-      linkifier = null, links, autolinker;
+  var i,
+    j,
+    l,
+    tokens,
+    token,
+    text,
+    nodes,
+    ln,
+    pos,
+    level,
+    htmlLinkLevel,
+    blockTokens = state.tokens,
+    linkifier = null,
+    links,
+    autolinker;
 
-  if (!state.options.linkify) { return; }
+  if (!state.options.linkify) {
+    return;
+  }
 
   for (j = 0, l = blockTokens.length; j < l; j++) {
-    if (blockTokens[j].type !== 'inline') { continue; }
+    if (blockTokens[j].type !== "inline") {
+      continue;
+    }
     tokens = blockTokens[j].children;
 
     htmlLinkLevel = 0;
@@ -76,16 +88,19 @@ module.exports = function linkify(state) {
       token = tokens[i];
 
       // Skip content of markdown links
-      if (token.type === 'link_close') {
+      if (token.type === "link_close") {
         i--;
-        while (tokens[i].level !== token.level && tokens[i].type !== 'link_open') {
+        while (
+          tokens[i].level !== token.level &&
+          tokens[i].type !== "link_open"
+        ) {
           i--;
         }
         continue;
       }
 
       // Skip content of html tag links
-      if (token.type === 'htmltag') {
+      if (token.type === "htmltag") {
         if (isLinkOpen(token.content) && htmlLinkLevel > 0) {
           htmlLinkLevel--;
         }
@@ -93,10 +108,11 @@ module.exports = function linkify(state) {
           htmlLinkLevel++;
         }
       }
-      if (htmlLinkLevel > 0) { continue; }
+      if (htmlLinkLevel > 0) {
+        continue;
+      }
 
-      if (token.type === 'text' && LINK_SCAN_RE.test(token.content)) {
-
+      if (token.type === "text" && LINK_SCAN_RE.test(token.content)) {
         // Init linkifier in lazy manner, only if required.
         if (!linkifier) {
           linkifier = createLinkifier();
@@ -108,53 +124,60 @@ module.exports = function linkify(state) {
         links.length = 0;
         autolinker.link(text);
 
-        if (!links.length) { continue; }
+        if (!links.length) {
+          continue;
+        }
 
         // Now split string to nodes
         nodes = [];
         level = token.level;
 
         for (ln = 0; ln < links.length; ln++) {
-
-          if (!state.inline.validateLink(links[ln].url)) { continue; }
+          if (!state.inline.validateLink(links[ln].url)) {
+            continue;
+          }
 
           pos = text.indexOf(links[ln].text);
 
           if (pos) {
             level = level;
             nodes.push({
-              type: 'text',
+              type: "text",
               content: text.slice(0, pos),
               level: level
             });
           }
           nodes.push({
-            type: 'link_open',
+            type: "link_open",
             href: links[ln].url,
-            title: '',
+            title: "",
             level: level++
           });
           nodes.push({
-            type: 'text',
+            type: "text",
             content: links[ln].text,
             level: level
           });
           nodes.push({
-            type: 'link_close',
+            type: "link_close",
             level: --level
           });
           text = text.slice(pos + links[ln].text.length);
         }
         if (text.length) {
           nodes.push({
-            type: 'text',
+            type: "text",
             content: text,
             level: level
           });
         }
 
         // replace current node
-        blockTokens[j].children = tokens = [].concat(tokens.slice(0, i), nodes, tokens.slice(i + 1));
+        blockTokens[j].children = tokens = [].concat(
+          tokens.slice(0, i),
+          nodes,
+          tokens.slice(i + 1)
+        );
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "argparse": "1.0.10",
-    "autolinker": "~0.28.0"
+    "autolinker": "^3.0.0"
   },
   "devDependencies": {
     "ansi": "^0.3.0",

--- a/test/fixtures/remarkable/linkify.txt
+++ b/test/fixtures/remarkable/linkify.txt
@@ -38,11 +38,11 @@ www.example.org
 .
 
 
-properly cut domain end
+support unicode in domain end
 .
 www.example.org版权所有
 .
-<p><a href="http://www.example.org">www.example.org</a>版权所有</p>
+<p><a href="http://www.example.org版权所有">www.example.org版权所有</a></p>
 .
 
 
@@ -60,5 +60,5 @@ test@example.com
 mailto:test@example.com
 .
 <p><a href="mailto:test@example.com">test@example.com</a></p>
-<p><a href="mailto:test@example.com">mailto:test@example.com</a></p>
+<p>mailto:<a href="mailto:test@example.com">test@example.com</a></p>
 .

--- a/test/remarkable.js
+++ b/test/remarkable.js
@@ -1,21 +1,18 @@
 /*global describe*/
-'use strict';
+"use strict";
 
+var path = require("path");
 
-var path = require('path');
+var utils = require("./utils");
+var Remarkable = require("../");
 
-
-var utils = require('./utils');
-var Remarkable = require('../');
-
-
-describe('remarkable', function () {
-  var md = new Remarkable('full', {
+describe("remarkable", function() {
+  var md = new Remarkable("full", {
     html: true,
-    langPrefix: '',
+    langPrefix: "",
     typographer: true,
     linkify: true
   });
 
-  utils.addTests(path.join(__dirname, 'fixtures/remarkable'), md);
+  utils.addTests(path.join(__dirname, "fixtures/remarkable"), md);
 });


### PR DESCRIPTION
the behavior now matches that of Github:

https://gist.github.com/matthijsgroen/316d4b6dcd28127c4e1f374774b565d7

also updating autolinker has performance gains, and a license entry in
the package.json in the proper format.

The current used version of autolinker has an entry of:
`"license": "MIT Licensed. http://www.opensource.org/licenses/mit-license.php",`

https://github.com/gregjacobs/Autolinker.js/blob/0.15.3/package.json#L25

And this update has an entry of:

`"license": "MIT",`

which is compatible to the SPDX license identifier list: https://spdx.org/licenses/